### PR TITLE
Pluggable factorization backends + spOT-NMF Integration

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = mosaicmpi
-version = 2.8.8
+version = 2.9.0
 author = Ted Verhey
 author_email = tbverhey@ucalgary.ca
 description = mosaicMPI: Mosaic Multi-resolution Program Integration

--- a/src/mosaicmpi/__init__.py
+++ b/src/mosaicmpi/__init__.py
@@ -17,6 +17,8 @@ logging_started = False
 if hasattr(ad, "settings") and hasattr(ad.settings, "allow_write_nullable_strings"):
     ad.settings.allow_write_nullable_strings = True
 
+from . import factorization
+from .factorization import register_factorizer
 from .dataset import Dataset
 from .config import Config
 from .integration import Integration

--- a/src/mosaicmpi/cli.py
+++ b/src/mosaicmpi/cli.py
@@ -16,6 +16,7 @@ import sys
 from itertools import product
 from typing import Optional, Mapping
 
+import yaml
 from tqdm import tqdm
 import click
 import pandas as pd
@@ -669,15 +670,29 @@ def cmd_select_hvf_cnmf(name, output_dir, input, stratify_by, stratify_mode, min
 @click.option(
     '--beta_loss', type=click.Choice(["frobenius", "kullback-leibler"]), default="frobenius", show_default=True,
     help="Measure of beta-divergence to be minimized.")
-def cmd_initialize_cnmf(name, output_dir, k_range, k, n_iter, seed, beta_loss):
+@click.option(
+    '--algorithm', type=str, default="cnmf", show_default=True,
+    help="Per-iteration factorization backend. 'cnmf' uses scikit-learn NMF; "
+    "alternative backends (e.g. 'spotnmf', which requires the spot-nmf package) "
+    "plug in via mosaicmpi.factorization. Consensus, k-selection and output "
+    "format are identical regardless of backend.")
+@click.option(
+    '--algorithm_param', type=(str, str), multiple=True, metavar="KEY VALUE",
+    help="Backend-specific parameter for the selected --algorithm, given as a "
+    "KEY VALUE pair (values are parsed as YAML scalars). May be supplied multiple "
+    "times. Ignored by the built-in 'cnmf' backend. E.g. --algorithm_param eps 0.05")
+def cmd_initialize_cnmf(name, output_dir, k_range, k, n_iter, seed, beta_loss, algorithm, algorithm_param):
     """
-    
+
     Initialize cNMF with inputs for factorization.
-    
+
     Examples:
         \b
         # specify k with ranges: 10-100 (by 10s), and 100-500 (by 100s)
         mosaicmpi initialize-cnmf --k_range 10 100 10 --k_range 100 500 100
+        \b
+        # use the spot-nmf (optimal transport) factorization backend
+        mosaicmpi initialize-cnmf -n mydata -k 10 --algorithm spotnmf --algorithm_param eps 0.05
     """
     os.makedirs(os.path.join(output_dir, name, "logs"), exist_ok=True)
     utils.start_logging(os.path.join(output_dir, name, "logs", "logfile.txt"))
@@ -693,9 +708,16 @@ def cmd_initialize_cnmf(name, output_dir, k_range, k, n_iter, seed, beta_loss):
         sys.exit(1)
     logging.info("Setting up factorization for the following ranks: " + ", ".join([str(k) for k in kvals]))
     
+    # parse backend-specific parameters (KEY VALUE pairs), interpreting values as YAML scalars
+    factorizer_params = {key: yaml.safe_load(value) for key, value in algorithm_param}
+    if algorithm != "cnmf":
+        logging.info(f"Using factorization backend: '{algorithm}'" +
+                     (f" with parameters {factorizer_params}" if factorizer_params else ""))
+
     # prepare cNMF directory for factorization
     dataset = Dataset.from_h5ad(os.path.join(output_dir, name, name + ".h5ad"))
-    dataset.initialize_cnmf(cnmf_output_dir = output_dir, cnmf_name=name, kvals=kvals, n_iter=n_iter, beta_loss=beta_loss, seed=seed)
+    dataset.initialize_cnmf(cnmf_output_dir = output_dir, cnmf_name=name, kvals=kvals, n_iter=n_iter,
+                            beta_loss=beta_loss, seed=seed, algorithm=algorithm, factorizer_params=factorizer_params)
 
 
 @click.command(name="factorize")

--- a/src/mosaicmpi/cnmf.py
+++ b/src/mosaicmpi/cnmf.py
@@ -1,6 +1,7 @@
 ## Code adapted and improved from https://github.com/dylkot/cNMF/blob/master/src/cnmf/cnmf.py
 
 from . import utils
+from . import factorization
 
 import os
 import errno
@@ -160,13 +161,24 @@ class cNMF():
     """Legacy cNMF object based off of the cNMF package
     """
 
-    def __init__(self, output_dir=".", name=None):
+    def __init__(self, output_dir=".", name=None, algorithm="cnmf", factorizer_params=None):
         """
 
         :param output_dir: Place to put cNMF resutls, defaults to "."
         :type output_dir: str, optional
         :param name: A name for this analysis. Will be prefixed to all output files, defaults to automatically generated timestamp (and random string).
         :type name: str, optional
+        :param algorithm: Name of the per-iteration factorization backend to use.
+            ``"cnmf"`` (default) uses scikit-learn NMF; other names select a
+            pluggable backend registered via :mod:`mosaicmpi.factorization`
+            (e.g. ``"spotnmf"``). If a persisted factorization config is found on
+            disk, its algorithm takes precedence so that the ``factorize`` and
+            ``postprocess`` steps reconstruct the same backend chosen at
+            initialization time.
+        :type algorithm: str, optional
+        :param factorizer_params: Backend-specific keyword arguments passed to
+            the factorizer callable (ignored by the built-in ``"cnmf"`` backend).
+        :type factorizer_params: dict, optional
         """
 
 
@@ -176,8 +188,14 @@ class cNMF():
             rand_hash =  uuid.uuid4().hex[:6]
             name = '%s_%s' % (now.strftime("%Y_%m_%d"), rand_hash)
         self.name = name
+        self.algorithm = algorithm
+        self.factorizer_params = dict(factorizer_params) if factorizer_params else {}
         self.paths = None
         self._initialize_dirs()
+        # If a factorization backend was persisted at initialization time, adopt
+        # it (this lets `factorize`/`postprocess` reconstruct the right backend
+        # without re-passing the algorithm on the command line).
+        self._load_factorization_config()
 
 
     def _initialize_dirs(self):
@@ -189,6 +207,7 @@ class cNMF():
                 'normalized_counts' : os.path.join(self.output_dir, self.name, 'cnmf_tmp', self.name+'.norm_counts.h5ad'),
                 'nmf_replicate_parameters' :  os.path.join(self.output_dir, self.name, 'cnmf_tmp', self.name+'.nmf_params.df.npz'),
                 'nmf_run_parameters' :  os.path.join(self.output_dir, self.name, 'cnmf_tmp', self.name+'.nmf_idvrun_params.yaml'),
+                'factorization_config' :  os.path.join(self.output_dir, self.name, 'cnmf_tmp', self.name+'.factorization.yaml'),
                 'nmf_genes_list' :  os.path.join(self.output_dir, self.name, self.name+'.overdispersed_genes.txt'),
 
                 'tpm' :  os.path.join(self.output_dir, self.name, 'cnmf_tmp', self.name+'.tpm.h5ad'),
@@ -283,6 +302,27 @@ class cNMF():
             yaml.dump(run_params, F)
 
 
+    def save_factorization_config(self):
+        """Persist the selected factorization backend and its parameters so that
+        subsequent ``factorize``/``postprocess`` steps (which reconstruct a bare
+        ``cNMF(output_dir, name)`` object) use the same backend.
+        """
+        self._initialize_dirs()
+        config = {'algorithm': self.algorithm, 'factorizer_params': self.factorizer_params}
+        with open(self.paths['factorization_config'], 'w') as F:
+            yaml.dump(config, F)
+
+
+    def _load_factorization_config(self):
+        """Adopt a persisted factorization backend if one exists on disk."""
+        config_path = self.paths['factorization_config']
+        if os.path.exists(config_path) and os.path.getsize(config_path) > 0:
+            with open(config_path) as F:
+                config = yaml.load(F, Loader=yaml.FullLoader) or {}
+            self.algorithm = config.get('algorithm', self.algorithm)
+            self.factorizer_params = config.get('factorizer_params', self.factorizer_params) or {}
+
+
     def _nmf(self, X, nmf_kwargs):
         """
 
@@ -326,6 +366,13 @@ class cNMF():
         norm_counts = ad.read_h5ad(self.paths['normalized_counts'])
         _nmf_kwargs = yaml.load(open(self.paths['nmf_run_parameters']), Loader=yaml.FullLoader)
 
+        # Resolve the per-iteration factorization backend. `None` means use the
+        # built-in scikit-learn path (`self._nmf`); a callable is an alternative
+        # backend (e.g. spot-nmf) selected via `self.algorithm`.
+        factorizer = factorization.get_factorizer(self.algorithm)
+        if factorizer is not None:
+            logging.info(f"Factorizing with backend '{self.algorithm}'.")
+
         jobs_for_this_worker = _worker_filter(range(len(run_params)), worker_i, total_workers)
         for idx in jobs_for_this_worker:
             p = run_params.iloc[idx, :]
@@ -334,7 +381,16 @@ class cNMF():
             _nmf_kwargs['random_state'] = p['nmf_seed']
             _nmf_kwargs['n_components'] = p['n_components']
 
-            (spectra, usages) = self._nmf(norm_counts.X, _nmf_kwargs)
+            if factorizer is None:
+                (spectra, usages) = self._nmf(norm_counts.X, _nmf_kwargs)
+            else:
+                (spectra, usages) = factorizer(
+                    norm_counts.X,
+                    n_components=int(p['n_components']),
+                    random_state=int(p['nmf_seed']),
+                    var_names=norm_counts.var.index,
+                    params=self.factorizer_params,
+                )
             spectra = pd.DataFrame(spectra,
                                    index=np.arange(1, _nmf_kwargs['n_components']+1),
                                    columns=norm_counts.var.index)

--- a/src/mosaicmpi/dataset.py
+++ b/src/mosaicmpi/dataset.py
@@ -1078,8 +1078,10 @@ class Dataset():
                         kvals: Collection = range(2, 61),
                         n_iter: int = 200,
                         beta_loss: str = "kullback-leibler",
-                        seed: Optional[int] = None) -> cnmf.cNMF:
-        """Initialize a cNMF run for subsequent factorization.
+                        seed: Optional[int] = None,
+                        algorithm: str = "cnmf",
+                        factorizer_params: Optional[dict] = None) -> cnmf.cNMF:
+        """Initialize a factorization run for subsequent factorization.
 
         :param cnmf_output_dir: Output directory for cNMF results
         :type cnmf_output_dir: str
@@ -1093,10 +1095,19 @@ class Dataset():
         :type beta_loss: str, optional
         :param seed: Random seed for reproducibility, defaults to None
         :type seed: Optional[int], optional
+        :param algorithm: Per-iteration factorization backend. ``"cnmf"`` (default)
+            uses scikit-learn NMF; alternatives (e.g. ``"spotnmf"``) are pluggable
+            backends registered via :mod:`mosaicmpi.factorization`. The consensus,
+            k-selection and output format are identical regardless of backend.
+        :type algorithm: str, optional
+        :param factorizer_params: Backend-specific keyword arguments forwarded to
+            the alternative factorizer (ignored by the built-in ``"cnmf"`` backend).
+        :type factorizer_params: Optional[dict], optional
         :return: cNMF object
         :rtype: :class:`mosaicmpi.cnmf.cNMF`
         """
-        cnmf_obj = cnmf.cNMF(output_dir=cnmf_output_dir, name=cnmf_name)
+        cnmf_obj = cnmf.cNMF(output_dir=cnmf_output_dir, name=cnmf_name,
+                             algorithm=algorithm, factorizer_params=factorizer_params)
         
         # write TPM (normalized) data
         tpm = ad.AnnData(self.to_df(normalized=True))
@@ -1131,12 +1142,16 @@ class Dataset():
         # save parameters for factorization step
         cnmf_obj.save_nmf_iter_params(*cnmf_obj.get_nmf_iter_params(ks=kvals, n_iter=n_iter, random_state_seed=seed, beta_loss=beta_loss))
 
+        # persist the chosen factorization backend so `factorize`/`postprocess` reuse it
+        cnmf_obj.save_factorization_config()
+
         # save parameters in AnnData object
         self.adata.uns["cnmf"] = cnmf_obj.get_nmf_iter_params(ks=kvals, n_iter=n_iter, random_state_seed=seed, beta_loss=beta_loss)[1]  # dict of cnmf parameters
-        
+        self.adata.uns["factorization_algorithm"] = algorithm
+
         # output dataset with new information on HVF and cNMF parameters
         self.write_h5ad(os.path.join(cnmf_output_dir, cnmf_name, cnmf_name + ".h5ad"))
-        self.append_to_history(f"cNMF parameters added. cNMF inputs initialized in {cnmf_output_dir}/{cnmf_name}")
+        self.append_to_history(f"Factorization parameters added (algorithm='{algorithm}'). Inputs initialized in {cnmf_output_dir}/{cnmf_name}")
         return cnmf_obj
     
     def add_cnmf_results(self, cnmf_output_dir, cnmf_name, local_density_threshold: float = None, local_neighborhood_size: float = None):

--- a/src/mosaicmpi/dataset.py
+++ b/src/mosaicmpi/dataset.py
@@ -1,5 +1,5 @@
 
-from . import utils, cnmf, biomart, __version__
+from . import utils, cnmf, biomart, factorization, __version__
 
 import numpy as np
 import pandas as pd
@@ -1106,6 +1106,11 @@ class Dataset():
         :return: cNMF object
         :rtype: :class:`mosaicmpi.cnmf.cNMF`
         """
+        # Fail fast: resolve the factorization backend now (before writing any
+        # inputs) so an unknown algorithm or a missing backend package raises here
+        # rather than later during the `factorize` step.
+        factorization.get_factorizer(algorithm)
+
         cnmf_obj = cnmf.cNMF(output_dir=cnmf_output_dir, name=cnmf_name,
                              algorithm=algorithm, factorizer_params=factorizer_params)
         

--- a/src/mosaicmpi/factorization.py
+++ b/src/mosaicmpi/factorization.py
@@ -1,0 +1,95 @@
+"""Pluggable matrix-factorization backends for mosaicMPI.
+
+mosaicMPI's :class:`mosaicmpi.cnmf.cNMF` engine owns the whole consensus,
+refit, k-selection and on-disk-output machinery. The *only* algorithm-specific
+step is the per-iteration factorization of a single (cells x genes) matrix into
+a spectra matrix (programs x genes) and a usage matrix (cells x programs).
+
+This module lets that single step be swapped for an alternative implementation
+(e.g. the optimal-transport factorization in the ``spot-nmf`` package) while
+every other part of the pipeline -- and, critically, the output file format read
+back by :meth:`mosaicmpi.dataset.Dataset.add_cnmf_results` -- stays identical.
+
+A backend is just a callable with the signature::
+
+    factorizer(X, n_components, random_state, var_names=None, params=None)
+        -> (spectra, usages)
+
+where
+
+* ``X``            : ndarray / sparse matrix, cells x genes (non-negative)
+* ``n_components`` : int, the rank k
+* ``random_state`` : int seed for reproducibility
+* ``var_names``    : optional gene labels (columns of ``X``)
+* ``params``       : optional dict of backend-specific keyword arguments
+* returns ``spectra`` (k x genes) and ``usages`` (cells x k) as ndarrays,
+  matching the orientation of scikit-learn's ``non_negative_factorization``
+  return value ``(usages, spectra, n_iter)``.
+
+The built-in ``"cnmf"`` backend is registered lazily as ``None`` -- a sentinel
+telling :meth:`cNMF.factorize` to use its own scikit-learn code path unchanged.
+External packages register their own backend by calling
+:func:`register_factorizer`, either eagerly at import time or via the plugin
+autoload map below.
+"""
+
+import importlib
+import logging
+
+# name -> callable (or None for the built-in scikit-learn/cNMF path)
+_BACKENDS = {
+    "cnmf": None,
+}
+
+# Optional backends that live in separate packages. When an unknown algorithm is
+# requested, we try to import the mapped module; that module is expected to call
+# register_factorizer() at import time. This keeps the dependency optional and
+# one-directional (mosaicMPI does not import these packages unless asked).
+_PLUGIN_MODULES = {
+    "spotnmf": "spotnmf.mosaic",
+}
+
+
+def register_factorizer(name, factorizer):
+    """Register a factorization backend under ``name``.
+
+    :param name: Identifier used by ``--algorithm`` / ``initialize_cnmf(algorithm=...)``.
+    :type name: str
+    :param factorizer: Callable implementing the backend contract, or ``None``
+        to select the built-in scikit-learn/cNMF path.
+    :type factorizer: callable or None
+    """
+    _BACKENDS[name] = factorizer
+    logging.info(f"Registered factorization backend: '{name}'")
+
+
+def available_factorizers():
+    """Return the list of currently registered backend names."""
+    return sorted(_BACKENDS)
+
+
+def get_factorizer(name):
+    """Return the backend callable registered under ``name``.
+
+    Returns ``None`` for the built-in ``"cnmf"`` path. If ``name`` is not yet
+    registered but is a known plugin, the plugin module is imported (which is
+    expected to self-register) before looking it up again.
+
+    :raises ValueError: if ``name`` is unknown and no plugin provides it.
+    """
+    if name not in _BACKENDS and name in _PLUGIN_MODULES:
+        module = _PLUGIN_MODULES[name]
+        try:
+            importlib.import_module(module)
+        except ImportError as e:
+            raise ValueError(
+                f"Factorization backend '{name}' requires the module '{module}', "
+                f"which could not be imported: {e}. Install the corresponding "
+                f"package (e.g. `pip install spot-nmf`) to use this backend."
+            ) from e
+    if name not in _BACKENDS:
+        raise ValueError(
+            f"Unknown factorization backend '{name}'. "
+            f"Available: {', '.join(available_factorizers())}."
+        )
+    return _BACKENDS[name]


### PR DESCRIPTION
## Pluggable factorization backends

### Summary

This PR makes the per-iteration matrix factorization in mosaicMPI **pluggable**,
so an alternative factorizer can be used in place of scikit-learn NMF without
touching consensus, rank selection, result I/O, or any downstream integration /
network code. The default behavior is unchanged (`algorithm="cnmf"`).

The motivating use case is running mosaicMPI's consensus + integration pipeline
on top of an optimal-transport NMF ([spOT-NMF](https://github.com/MorrissyLab/spOT-NMF)),
but the mechanism is generic — any package can register a backend.

### Motivation

The `cNMF` engine already owns everything except the algorithm itself:
replicate management, consensus clustering, refit, TPM/z-score spectra,
k-selection, and the on-disk output format that `Dataset.add_cnmf_results`
reads back. The only algorithm-specific step is one call inside
`cNMF.factorize()` that factorizes a `cells × genes` matrix into
`spectra (k × genes)` + `usages (cells × k)`. Making just that step swappable
gives alternative factorizers full access to the rest of the framework at
minimal cost and risk.

### What changed

- **`factorization.py` (new)** — a small backend registry:
  - `register_factorizer(name, fn)` / `get_factorizer(name)` / `available_factorizers()`
  - the built-in `"cnmf"` backend is a sentinel (`None`) meaning "use the existing
    scikit-learn code path unchanged"
  - unknown-but-known names are autoloaded from a plugin map
    (`{"spotnmf": "spotnmf.mosaic"}`), and the imported module self-registers.
    A backend is any callable:
    `factorizer(X, n_components, random_state, var_names=None, params=None) -> (spectra, usages)`.

- **`cnmf.py`** — `cNMF.__init__` gains `algorithm="cnmf"` and `factorizer_params`.
  `factorize()` dispatches to the selected backend (sentinel `None` → the original
  `_nmf` path). The chosen backend + params are persisted to a small
  `*.factorization.yaml` sidecar and auto-reloaded, so `factorize`/`postprocess`
  reconstruct the right backend from a bare `cNMF(output_dir, name)` with no extra
  flags. **Refits (`refit_usage`/`refit_spectra`) intentionally remain
  scikit-learn NNLS** — they solve a fixed-basis least-squares problem and are
  algorithm-agnostic.

- **`dataset.py`** — `initialize_cnmf(...)` gains `algorithm` / `factorizer_params`,
  persists the factorization config, and records `adata.uns["factorization_algorithm"]`.

- **`cli.py`** — `initialize-cnmf` gains `--algorithm` and repeatable
  `--algorithm_param KEY VALUE` (values parsed as YAML scalars). `factorize` and
  `postprocess` need **no** new flags — they read the persisted config.

- **`__init__.py`** — exposes `factorization` and `register_factorizer`.

### Backward compatibility

- Default is `algorithm="cnmf"`, which routes to the exact existing scikit-learn
  code path. No behavior change for existing runs or result directories (the
  sidecar is simply absent and treated as `cnmf`).
- The on-disk output format is unchanged, so `add_cnmf_results` and all downstream
  consumers (`Integration`, `Network`, plots) work identically regardless of backend.

### Usage

```bash
# default (scikit-learn cNMF) — unchanged
mosaicmpi initialize-cnmf -n mydata -k 10

# alternative backend, e.g. spOT-NMF (requires the spot-nmf package installed)
mosaicmpi initialize-cnmf -n mydata -k 10 --algorithm spotnmf --algorithm_param eps 0.05
mosaicmpi factorize   -n mydata
mosaicmpi postprocess -n mydata




